### PR TITLE
make only text-part of (short) PopupIcons clickable

### DIFF
--- a/src/PopupIcon.js
+++ b/src/PopupIcon.js
@@ -21,6 +21,7 @@ L.PopupIcon = L.Icon.extend({
 		div.style.position = 'absolute';
 		div.style.width = width + 'px';
 		div.style.bottom = '-3px';
+		div.style.pointerEvents = 'none';
 		div.style.left = (-width / 2) + 'px';
 
 		var contentDiv = document.createElement('div');
@@ -33,6 +34,7 @@ L.PopupIcon = L.Icon.extend({
 		contentDiv.style.borderRadius = '5px';
 		contentDiv.style.margin = '0 auto';
 		contentDiv.style.display = 'table';
+		contentDiv.style.pointerEvents = 'auto';
 
 		var tipcDiv = document.createElement('div');
 		tipcDiv.className = 'leaflet-popup-tip-container';


### PR DESCRIPTION
I see that icons must have a fixed width in order to center them. But it resulted in the whole area being clickable (even the transparent areas right and left of the text). This behaviour is especially confusing if texts are short, but right next to each other.

This uses [pointer-events](http://caniuse.com/pointer-events) to make the transparent areas right and left of PopupIcons non-clickable. And it doesn't harm older browsers.
